### PR TITLE
Add nonce test for bootstrap scripts

### DIFF
--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1353,6 +1353,36 @@ createNextDescribe(
           }
         })
 
+        it('includes a nonce value with bootstrap scripts when Content-Security-Policy header is defined', async () => {
+          // A random nonce value, base64 encoded.
+          const nonce = 'cmFuZG9tCg=='
+
+          // Validate all the cases where we could parse the nonce.
+          const policies = [
+            `script-src 'nonce-${nonce}'`, // base case
+            `   script-src   'nonce-${nonce}' `, // extra space added around sources and directive
+            `style-src 'self'; script-src 'nonce-${nonce}'`, // extra directives
+            `script-src 'self' 'nonce-${nonce}' 'nonce-othernonce'`, // extra nonces
+            `default-src 'nonce-othernonce'; script-src 'nonce-${nonce}';`, // script and then fallback case
+            `default-src 'nonce-${nonce}'`, // fallback case
+          ]
+
+          for (const policy of policies) {
+            const $ = await renderWithPolicy(policy)
+
+            // Find all the script tags without src attributes.
+            const elements = $('script[src]')
+
+            // Expect there to be at least 1 script tag without a src attribute.
+            expect(elements.length).toBeGreaterThan(0)
+
+            // Expect all inline scripts to have the nonce value.
+            elements.each((i, el) => {
+              expect(el.attribs['nonce']).toBe(nonce)
+            })
+          }
+        })
+
         it('includes an integrity attribute on scripts', async () => {
           const $ = await next.render$('/dashboard')
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Add test for `nonce` in bootstrap scripts.

- Added test `includes a nonce value with bootstrap scripts when Content-Security-Policy header is defined` to `test/e2e/app-dir/app/index.test.ts`

I confirmed that running `pnpm testheadless test/e2e/app-dir/app/ -t "includes a nonce value with bootstrap scripts when Content-Security-Policy header is defined"` passes in this PR, but fails in the most recent version of next.js fails with the following message:

```
  ● app dir › Subresource Integrity › includes a nonce value with bootstrap scripts when Content-Security-Policy header is defined

    expect(received).toBe(expected) // Object.is equality

    Expected: "cmFuZG9tCg=="
    Received: undefined

      1379 |             // Expect all inline scripts to have the nonce value.
      1380 |             elements.each((i, el) => {
    > 1381 |               expect(el.attribs['nonce']).toBe(nonce)
           |                                           ^
      1382 |             })
      1383 |           }
      1384 |         })

```
